### PR TITLE
PV correction UI changes and new way to do test

### DIFF
--- a/core/BestMoveFinder.hpp
+++ b/core/BestMoveFinder.hpp
@@ -235,6 +235,7 @@ private:
         if constexpr(nodeType != PVNode){
             int lastEval = transposition.get_eval(state, alpha, beta, depth, lastBest);
             if(lastEval != INVALID){
+                beginLine(rootDist);
                 return fromTT(lastEval, rootDist);
             }
         }else{
@@ -270,7 +271,7 @@ private:
             if(inCheck)
                 score = MINIMUM+rootDist;
             else score = MIDDLE;
-            if constexpr(nodeType == PVNode)if(score > alpha)beginLine(rootDist);
+            if constexpr(nodeType == PVNode)beginLine(rootDist);
             return score;
         }
         if(order.nbMoves == 1){
@@ -280,7 +281,7 @@ private:
             int sc = -negamax<-nodeType, limitWay, mateSearch>(depth, state, -beta, -alpha, lastChange, relDepth+1);
             eval.undoMove(order.moves[0], !state.friendlyColor());
             state.undoLastMove<false>();
-            if constexpr(nodeType != PVNode)if((running || limitWay == 2) && sc > alpha)transfer(rootDist, order.moves[0]);
+            if constexpr(nodeType != PVNode)transfer(rootDist, order.moves[0]);
             return sc;
         }
         order.init(state.friendlyColor(), lastBest, getPVMove(rootDist), history, relDepth, state, generator, depth > 5);

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -285,6 +285,18 @@ void doUCI(string UCI_instruction, Chess& state){
             }
         }
         printf("search score: (%.0f %.0f) (%.0f %.0f)", scoreThird.first, scoreThird.second, scoreAll.first, scoreAll.second);
+    }else if(command == "arch"){
+#ifdef __AVX512F__
+        printf("arch: AVX512")
+#elif defined(__AVX2__)
+        printf("arch: AVX2\n");
+#elif defined(__AVX__)
+        printf("arch: AVX\n");
+#elif defined(__SSE2__)
+        printf("arch: SSE2\n");
+#else
+        printf("arch: unknow\n");
+#endif
     }
     //Implement actual logic for UCI management
 }


### PR DESCRIPTION
correction of the PV, add the command arch that gives you the arch compiled on, modify the test manager to avoid the most concurrency. stopped LTC test:
```
Elo   | 3.3383021052286486 +/- 4.454820479678987
SPRT  | 60+0.6s
LLR   | 1.0572857831994529 (-2.9444389791664394, 2.9444389791664394) [0, 5]
Games | N: 13259 W: 4238 L: 4110 D: 4911
Penta | [572, 1429, 2449, 1618, 541]
```